### PR TITLE
Replace quickTemp with broccoli-caching-writer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,19 @@
-var fs = require('fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
 var includePathSearcher = require('include-path-searcher');
-var quickTemp = require('quick-temp');
-var mapSeries = require('promise-map-series');
-var _ = require('lodash');
+var Writer = require('broccoli-caching-writer');
 var dargs = require('dargs');
 var spawn = require('win-spawn');
 var Promise = require('rsvp').Promise;
+var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = SassCompiler;
-function SassCompiler (sourceTrees, inputFile, outputFile, options) {
-  if (!(this instanceof SassCompiler)) return new SassCompiler(sourceTrees, inputFile, outputFile, options);
-  this.sourceTrees = sourceTrees;
+SassCompiler.prototype = Object.create(Writer.prototype);
+SassCompiler.prototype.constructor = SassCompiler;
+
+function SassCompiler (inputTree, inputFile, outputFile, options) {
+  if (!(this instanceof SassCompiler)) return new SassCompiler(inputTree, inputFile, outputFile, options);
+  this.inputTree = mergeTrees(inputTree);
   this.inputFile = inputFile;
   this.outputFile = outputFile;
   options = options || {};
@@ -27,87 +28,79 @@ function SassCompiler (sourceTrees, inputFile, outputFile, options) {
   };
 }
 
-SassCompiler.prototype.read = function (readTree) {
-  var self = this;
+SassCompiler.prototype.updateCache = function (srcDir, destDir) {
   var bundleExec = this.sassOptions.bundleExec;
-  quickTemp.makeOrRemake(this, '_tmpDestDir');
-  var destFile = this._tmpDestDir + '/' + this.outputFile;
+  var destFile = destDir + '/' + this.outputFile;
+  var includePaths = [srcDir];
+
   mkdirp.sync(path.dirname(destFile));
-  return mapSeries(this.sourceTrees, readTree)
-    .then(function (includePaths) {
-      includePaths.unshift(path.dirname(self.inputFile));
-      self.sassOptions.loadPath = self.sassOptions.loadPath.concat(includePaths);
-      var passedArgs = dargs(self.sassOptions, ['bundleExec']);
-      var args = [
-        'sass',
-        includePathSearcher.findFileSync(self.inputFile, includePaths),
-        destFile
-      ].concat(passedArgs);
 
-      if(bundleExec) {
-        args.unshift('bundle', 'exec');
+  includePaths.unshift(path.dirname(this.inputFile));
+  this.sassOptions.loadPath = this.sassOptions.loadPath.concat(includePaths);
+  var passedArgs = dargs(this.sassOptions, ['bundleExec']);
+  var args = [
+    'sass',
+    includePathSearcher.findFileSync(this.inputFile, includePaths),
+    destFile
+  ].concat(passedArgs);
+
+  if(bundleExec) {
+    args.unshift('bundle', 'exec');
+  }
+
+  if(path.extname(this.inputFile) === '.css') {
+    args.push('--scss');
+  }
+
+  return new Promise(function(resolve, reject) {
+    var cmd = args.shift();
+    var cp = spawn(cmd, args);
+
+    function isWarning(error) {
+      return /DEPRECATION WARNING/.test(error.toString()) || /WARNING:/.test(error.toString());
+    }
+
+    cp.on('error', function(err) {
+      if (isWarning(err)) {
+        console.warn(err);
+        return;
       }
 
-      if(path.extname(self.inputFile) === '.css') {
-        args.push('--scss');
-      }
-
-      return new Promise(function(resolve, reject) {
-        var cmd = args.shift();
-        var cp = spawn(cmd, args);
-
-        function isWarning(error) {
-          return /DEPRECATION WARNING/.test(error.toString()) || /WARNING:/.test(error.toString());
-        }
-
-        cp.on('error', function(err) {
-          if (isWarning(err)) {
-            console.warn(err);
-            return;
-          }
-
-          console.error('[broccoli-ruby-sass] '+ err);
-          reject(err);
-        });
-
-        var errors = '';
-
-        cp.on('data', function(data) {
-          // ignore deprecation warnings
-
-          if (isWarning(err)) {
-            console.warn(err);
-            return;
-          }
-
-          errors += data;
-        });
-
-        cp.stderr.on('data', function(data) {
-          if (!isWarning(data)) {
-            errors += data;
-          } else {
-            console.warn('[broccoli-ruby-sass] ' + data);
-          }
-        });
-
-        cp.on('close', function(code) {
-          if(errors) {
-            reject(errors);
-          }
-
-          if(code > 0) {
-            reject('broccoli-ruby-sass exited with error code ' + code);
-          }
-
-          resolve(self._tmpDestDir);
-        });
-
-        return self._tmpDestDir;
-      });
+      console.error('[broccoli-ruby-sass] '+ err);
+      reject(err);
     });
-};
 
-SassCompiler.prototype.cleanup = function () {
-  quickTemp.remove(this, '_tmpDestDir');
+    var errors = '';
+
+    cp.on('data', function(data) {
+      // ignore deprecation warnings
+
+      if (isWarning(err)) {
+        console.warn(err);
+        return;
+      }
+
+      errors += data;
+    });
+
+    cp.stderr.on('data', function(data) {
+      if (!isWarning(data)) {
+        errors += data;
+      } else {
+        console.warn('[broccoli-ruby-sass] ' + data);
+      }
+    });
+
+    cp.on('close', function(code) {
+      if(errors) {
+        reject(errors);
+      }
+
+      if(code > 0) {
+        reject('broccoli-ruby-sass exited with error code ' + code);
+      }
+
+      resolve();
+    });
+  });
 };

--- a/package.json
+++ b/package.json
@@ -34,14 +34,16 @@
     "broccoli": "^0.7.1"
   },
   "dependencies": {
-    "mkdirp": "^0.3.5",
-    "quick-temp": "^0.1.0",
-    "promise-map-series": "^0.2.0",
+    "broccoli-caching-writer": "^0.3.1",
+    "broccoli-merge-trees": "^0.1.4",
+    "broccoli-static-compiler": "^0.1.2",
     "dargs": "^0.1.0",
-    "win-spawn": "^2.0.0",
     "include-path-searcher": "^0.1.0",
     "lodash": "^2.4.1",
-    "broccoli-static-compiler": "^0.1.2",
-    "rsvp": "^3.0.6"
+    "mkdirp": "^0.3.5",
+    "promise-map-series": "^0.2.0",
+    "quick-temp": "^0.1.0",
+    "rsvp": "^3.0.6",
+    "win-spawn": "^2.0.0"
   }
 }

--- a/test/ruby-sass-test.js
+++ b/test/ruby-sass-test.js
@@ -14,14 +14,9 @@ describe('broccoli-ruby-sass', function() {
   var builtTo;
 
   function build() {
-    return new RSVP.Promise(function(resolve) {
-      var tree = broccoli.loadBrocfile();
-      var builder = new broccoli.Builder(tree);
-      return builder.build().then(function(dir) {
-        // TODO: If I don't do this, the file built does not exist to node, huh?
-        setTimeout(resolve.bind(null, dir), 750);
-      });
-    });
+    var tree = broccoli.loadBrocfile();
+    var builder = new broccoli.Builder(tree);
+    return builder.build();
   }
 
   beforeEach(function() {
@@ -31,7 +26,7 @@ describe('broccoli-ruby-sass', function() {
   });
 
   it('compiles templates with @extend', function() {
-    var actualPath = require('path').resolve('./' + builtTo + '/splitbutton.css');
+    var actualPath = require('path').resolve(builtTo + '/splitbutton.css');
     console.log(actualPath);
     var readActual = readFile.bind(null, actualPath);
     var readExpected = readFile.bind(null, './test/output/splitbutton.css');


### PR DESCRIPTION
This fixes #4 and should cache correctly when sass-tree is not changed.

I also fixed the test which was not passing for me. Test is passing again now.

I am using broccoli-merge-trees in this pr because this was the easiest way to not break backwards compatibility. For example ember-cli expects the first argument to the SassCompiler to be an array and most likely needs this behaviour to be able to swap out sass-compilers based on the sass broccoli plugin that is installed via npm.

Thanks for this project!
