### PR TITLE
Fix missing npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chai": "^1.9.1",
     "chai-as-promised": "^4.1.1",
     "mocha": "^1.18.2",
-    "broccoli": "^0.7.1"
+    "broccoli": "^0.7.2"
   },
   "dependencies": {
     "mkdirp": "^0.3.5",
@@ -41,7 +41,7 @@
     "win-spawn": "^2.0.0",
     "include-path-searcher": "^0.1.0",
     "lodash": "^2.4.1",
-    "broccoli-static-compiler": "^0.1.2",
+    "broccoli-static-compiler": "^0.1.4",
     "rsvp": "^3.0.6"
   }
 }


### PR DESCRIPTION
Some older dependencies have gone missing on npm

when including `"broccoli-ruby-sass": "^0.2.0"` in another repo:

```
npm ERR! Error: version not found: broccoli-static-compiler@0.1.2
```

`0.1.3` doesn't appear to be in npm either, so i upgraded to `0.1.4`

When trying to build this repo, another dependency appeared to be missing from npm too:

```
npm ERR! Error: version not found: broccoli-kitchen-sink-helpers@0.1.0
```

Thus I updated `broccoli` dep to `^0.7.2`
