### PR TITLE
fix loadPath issues

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,12 +1,21 @@
 var compileSass = require('./index');
 var pickFiles = require('broccoli-static-compiler');
+var mergeTrees = require('broccoli-merge-trees');
 
 var tree = pickFiles('test/input', {
   srcDir: '/',
   destDir: '/'
 });
 
-module.exports = compileSass(tree, 'splitbutton.scss', 'splitbutton.css', {
+var tree1 = compileSass(tree, 'splitbutton.scss', 'splitbutton.css', {
   outputStyle: 'expanded',
   sourceMap: 'none'
 });
+
+var tree2 = compileSass(tree, 'loadpath_main.scss', 'loadpath_main.css', {
+  outputStyle: 'expanded',
+  sourceMap: 'none',
+  loadPath: ['/loadpath']
+});
+
+module.exports = mergeTrees([tree1, tree2]);

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var Writer = require('broccoli-caching-writer');
 var dargs = require('dargs');
 var spawn = require('win-spawn');
 var Promise = require('rsvp').Promise;
+var _ = require('lodash');
 
 SassCompiler.prototype = Object.create(Writer.prototype);
 SassCompiler.prototype.constructor = SassCompiler;
@@ -27,7 +28,7 @@ function SassCompiler (inputTree, inputFile, outputFile, options) {
     precision: options.precision,
     unixNewlines: options.unixNewlines
   };
-  this.customArgs = customArgs || [];
+  this.customArgs = options.customArgs || [];
 }
 
 SassCompiler.prototype.updateCache = function (srcDir, destDir) {
@@ -38,13 +39,22 @@ SassCompiler.prototype.updateCache = function (srcDir, destDir) {
   mkdirp.sync(path.dirname(destFile));
 
   includePaths.unshift(path.dirname(this.inputFile));
-  this.sassOptions.loadPath = this.sassOptions.loadPath.concat(includePaths);
-  var passedArgs = dargs(this.sassOptions, ['bundleExec']);
+
+  var loadPaths = this.sassOptions.loadPath;
+  var loadPath = srcDir.map(function(dir){
+    return loadPaths.map(function(loadPath){
+      return path.join(dir, loadPath);
+    });
+  });
+  loadPath = _.flatten(loadPath);
+  loadPath = loadPath.concat(includePaths);
+  loadPath = dargs({loadPath: loadPath});
+  var passedArgs = dargs(this.sassOptions, ['bundleExec', 'loadPath']);
   var args = [
     'sass',
     includePathSearcher.findFileSync(this.inputFile, includePaths),
     destFile
-  ].concat(passedArgs).concat(self.customArgs);
+  ].concat(passedArgs).concat(this.customArgs).concat(loadPath);
 
   if(bundleExec) {
     args.unshift('bundle', 'exec');
@@ -73,17 +83,6 @@ SassCompiler.prototype.updateCache = function (srcDir, destDir) {
     });
 
     var errors = '';
-
-    cp.on('data', function(data) {
-      // ignore deprecation warnings
-
-      if (isWarning(err)) {
-        console.warn(err);
-        return;
-      }
-
-      errors += data;
-    });
 
     cp.stderr.on('data', function(data) {
       if (!isWarning(data)) {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
   },
   "homepage": "https://github.com/joefiorini/broccoli-ruby-sass",
   "devDependencies": {
-    "rsvp": "^3.0.6",
+    "broccoli": "^0.13.2",
+    "broccoli-merge-trees": "^0.2.1",
     "chai": "^1.9.1",
     "chai-as-promised": "^4.1.1",
     "mocha": "^1.18.2",
-    "broccoli": "^0.7.2"
+    "rsvp": "^3.0.6"
   },
   "dependencies": {
     "broccoli": "^0.13.2",

--- a/test/input/loadpath/loaded.scss
+++ b/test/input/loadpath/loaded.scss
@@ -1,0 +1,3 @@
+body {
+  background-color: "red";
+}

--- a/test/input/loadpath_main.scss
+++ b/test/input/loadpath_main.scss
@@ -1,0 +1,1 @@
+@import "loaded";

--- a/test/output/loadpath_main.css
+++ b/test/output/loadpath_main.css
@@ -1,0 +1,3 @@
+body {
+  background-color: "red";
+}

--- a/test/ruby-sass-test.js
+++ b/test/ruby-sass-test.js
@@ -4,6 +4,7 @@ var readFile = denodeify(require('fs').readFile);
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 var broccoli = require('broccoli');
+var path = require('path');
 
 chai.use(chaiAsPromised);
 
@@ -29,6 +30,18 @@ describe('broccoli-ruby-sass', function() {
     var actualPath = require('path').resolve(builtTo + '/splitbutton.css');
     var readActual = readFile.bind(null, actualPath);
     var readExpected = readFile.bind(null, './test/output/splitbutton.css');
+    return RSVP.all([readActual(), readExpected()]).then(function(result) {
+      var actual = result[0].toString(), expected = result[1].toString();
+      assert(actual, 'actual is undefined');
+      assert(expected, 'expected is undefined');
+      assert.equal(actual, expected);
+    });
+  });
+
+  it("uses the load path correctly, e.g. doesn't look up in file system root", function(){
+    var actualPath = require('path').resolve(builtTo + '/loadpath_main.css');
+    var readActual = readFile.bind(null, actualPath);
+    var readExpected = readFile.bind(null, './test/output/loadpath_main.css');
     return RSVP.all([readActual(), readExpected()]).then(function(result) {
       var actual = result[0].toString(), expected = result[1].toString();
       assert(actual, 'actual is undefined');


### PR DESCRIPTION
Use the srcDir to build up the includedPaths
option more thoroughly. It uses path and the srcDir
to avoid using the wrong path. By wrong path,
I mean it should only use things inside the
broccoli tree passed in.

fixes GH-3
